### PR TITLE
Add getIdToken() & Fix current user not set before success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.1
+
+* Fix: Bug where the current user was not set before returning success.
+* New Basic functionality:
+    * `getIdToken()`
+
 ## 0.2.0
 
 * Complete rewrite to support the new FlutterFire structure.

--- a/android/src/main/kotlin/com/simpleclub/firebase_rest_auth/core/data/source/AuthDataSource.kt
+++ b/android/src/main/kotlin/com/simpleclub/firebase_rest_auth/core/data/source/AuthDataSource.kt
@@ -3,6 +3,8 @@ package com.simpleclub.firebase_rest_auth.core.data.source
 import com.google.android.gms.tasks.Task
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.internal.IdTokenListener
+import com.simpleclub.firebase_rest_auth.core.data.rest.models.FirebaseRestAuthUser
+import com.simpleclub.firebase_rest_auth.core.data.rest.models.identitytoolkit.SignInAnonymouslyResponse
 import com.simpleclub.firebase_rest_auth.core.data.rest.models.identitytoolkit.SignInWithCustomTokenRequest
 import com.simpleclub.firebase_rest_auth.core.data.rest.models.identitytoolkit.SignInWithCustomTokenResponse
 import com.simpleclub.firebase_rest_auth.core.data.rest.models.identitytoolkit.SignInWithEmailResponse
@@ -15,9 +17,10 @@ interface AuthDataSource {
 	fun signInWithCustomToken(token: String): Task<SignInWithCustomTokenResponse>
 	fun signInWithEmail(email: String, password: String): Task<SignInWithEmailResponse>
 	fun signInWithCredential(credential: Any): Task<*>
-	fun signInAnonymously(): Task<*>
+	fun signInAnonymously(): Task<SignInAnonymouslyResponse>
 	fun signOut()
 	fun getUser(): AuthUser?
+	fun setUser(user: FirebaseRestAuthUser?)
 
 	suspend fun getIdToken(): String?
 

--- a/android/src/main/kotlin/com/simpleclub/firebase_rest_auth/core/data/source/AuthDataSource.kt
+++ b/android/src/main/kotlin/com/simpleclub/firebase_rest_auth/core/data/source/AuthDataSource.kt
@@ -18,11 +18,11 @@ interface AuthDataSource {
 	fun signInWithEmail(email: String, password: String): Task<SignInWithEmailResponse>
 	fun signInWithCredential(credential: Any): Task<*>
 	fun signInAnonymously(): Task<SignInAnonymouslyResponse>
+	fun getIdToken(): String?
 	fun signOut()
 	fun getUser(): AuthUser?
-	fun setUser(user: FirebaseRestAuthUser?)
 
-	suspend fun getIdToken(): String?
+	fun setUser(user: FirebaseRestAuthUser?)
 
 	companion object {
 		private val INSTANCE = mutableMapOf<String, AuthDataSource>()

--- a/android/src/main/kotlin/com/simpleclub/firebase_rest_auth/framework/impl/AuthDataSourceImpl.kt
+++ b/android/src/main/kotlin/com/simpleclub/firebase_rest_auth/framework/impl/AuthDataSourceImpl.kt
@@ -4,6 +4,8 @@ import com.google.android.gms.tasks.Task
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.internal.IdTokenListener
 import com.simpleclub.firebase_rest_auth.core.data.rest.models.FirebaseRestAuth
+import com.simpleclub.firebase_rest_auth.core.data.rest.models.FirebaseRestAuthUser
+import com.simpleclub.firebase_rest_auth.core.data.rest.models.identitytoolkit.SignInAnonymouslyResponse
 import com.simpleclub.firebase_rest_auth.core.data.rest.models.identitytoolkit.SignInWithCustomTokenResponse
 import com.simpleclub.firebase_rest_auth.core.data.rest.models.identitytoolkit.SignInWithEmailResponse
 import com.simpleclub.firebase_rest_auth.core.data.source.AuthDataSource
@@ -33,7 +35,7 @@ class AuthDataSourceImpl(app: FirebaseApp) : AuthDataSource {
 		return mRestAuth.signInWithEmail(email, password)
 	}
 
-	override fun signInAnonymously(): Task<*> {
+	override fun signInAnonymously(): Task<SignInAnonymouslyResponse> {
 		return mRestAuth.signInAnonymously()
 	}
 
@@ -58,6 +60,10 @@ class AuthDataSourceImpl(app: FirebaseApp) : AuthDataSource {
 					providerInfo = it.providerInfo
 			)
 		}
+	}
+
+	override fun setUser(user: FirebaseRestAuthUser?) {
+		mRestAuth.currentUser = user;
 	}
 
 	override suspend fun getIdToken(): String? {

--- a/android/src/main/kotlin/com/simpleclub/firebase_rest_auth/framework/impl/AuthDataSourceImpl.kt
+++ b/android/src/main/kotlin/com/simpleclub/firebase_rest_auth/framework/impl/AuthDataSourceImpl.kt
@@ -66,7 +66,7 @@ class AuthDataSourceImpl(app: FirebaseApp) : AuthDataSource {
 		mRestAuth.currentUser = user;
 	}
 
-	override suspend fun getIdToken(): String? {
+	override fun getIdToken(): String? {
 		return mRestAuth.currentUser?.idToken
 	}
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_rest_auth
 description: Package for Firebase REST authentication within Flutter apps, no GMS required.
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/simpleclub/firebase_rest_auth
 
 environment:


### PR DESCRIPTION
Fixes an auth bug where the current user has not been set before returning success, resulting in a `null` user at implementation time.